### PR TITLE
Fix/nan 2 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,11 @@ language: node_js
 node_js:
   - "stable"
   - "4.0"
-  - "0.12"
-  - "0.10"
 
 install:
   - export CXX=g++-4.8
   - $CXX --version
-  - npm i 
+  - npm i
 
 before_install:
   - npm install -g node-gyp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "x509",
+  "version": "0.3.4",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "nan": "2.12.0"
+    "nan": "2.14.0"
   }
 }

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -7,26 +7,29 @@
 using namespace v8;
 
 void init(Local<Object> exports) {
+  v8::Isolate* isolate = exports->GetIsolate();
+  v8::Local<v8::Context> context = isolate->GetCurrentContext();
+
   Nan::Set(exports,
     Nan::New<String>("version").ToLocalChecked(),
     Nan::New<String>(VERSION).ToLocalChecked());
 
   Nan::Set(exports,
     Nan::New<String>("verify").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(verify)->GetFunction());
+    Nan::New<FunctionTemplate>(verify)->GetFunction(context).ToLocalChecked());
 
   Nan::Set(exports,
     Nan::New<String>("getAltNames").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_altnames)->GetFunction());
+    Nan::New<FunctionTemplate>(get_altnames)->GetFunction(context).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("getSubject").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_subject)->GetFunction());
+    Nan::New<FunctionTemplate>(get_subject)->GetFunction(context).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("getIssuer").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_issuer)->GetFunction());
+    Nan::New<FunctionTemplate>(get_issuer)->GetFunction(context).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("parseCert").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(parse_cert)->GetFunction());
+    Nan::New<FunctionTemplate>(parse_cert)->GetFunction(context).ToLocalChecked());
 }
 
 NODE_MODULE(x509, init)

--- a/src/addon.cc
+++ b/src/addon.cc
@@ -7,29 +7,26 @@
 using namespace v8;
 
 void init(Local<Object> exports) {
-  v8::Isolate* isolate = exports->GetIsolate();
-  v8::Local<v8::Context> context = isolate->GetCurrentContext();
-
   Nan::Set(exports,
     Nan::New<String>("version").ToLocalChecked(),
     Nan::New<String>(VERSION).ToLocalChecked());
 
   Nan::Set(exports,
     Nan::New<String>("verify").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(verify)->GetFunction(context).ToLocalChecked());
+    Nan::New<FunctionTemplate>(verify)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 
   Nan::Set(exports,
     Nan::New<String>("getAltNames").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_altnames)->GetFunction(context).ToLocalChecked());
+    Nan::New<FunctionTemplate>(get_altnames)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("getSubject").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_subject)->GetFunction(context).ToLocalChecked());
+    Nan::New<FunctionTemplate>(get_subject)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("getIssuer").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(get_issuer)->GetFunction(context).ToLocalChecked());
+    Nan::New<FunctionTemplate>(get_issuer)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
   Nan::Set(exports,
     Nan::New<String>("parseCert").ToLocalChecked(),
-    Nan::New<FunctionTemplate>(parse_cert)->GetFunction(context).ToLocalChecked());
+    Nan::New<FunctionTemplate>(parse_cert)->GetFunction(Nan::GetCurrentContext()).ToLocalChecked());
 }
 
 NODE_MODULE(x509, init)

--- a/src/x509.cc
+++ b/src/x509.cc
@@ -37,13 +37,13 @@ std::string parse_args(const Nan::FunctionCallbackInfo<v8::Value>& info) {
     Nan::ThrowTypeError("Certificate must be a string.");
     return std::string();
   }
-
-  if (info[0]->ToString()->Length() == 0) {
+  std::string val = *Nan::Utf8String(info[0]);
+  if (val.length() == 0) {
     Nan::ThrowTypeError("Certificate argument provided, but left blank.");
     return std::string();
   }
 
-  return *Nan::Utf8String(info[0]->ToString());
+  return val;
 }
 
 
@@ -52,8 +52,8 @@ NAN_METHOD(verify) {
   Nan::HandleScope scope;
   OpenSSL_add_all_algorithms();
 
-  std::string cert_path = *String::Utf8Value(info[0]->ToString());
-  std::string ca_bundlestr = *String::Utf8Value(info[1]->ToString());
+  std::string cert_path = *Nan::Utf8String(info[0]);
+  std::string ca_bundlestr = *Nan::Utf8String(info[1]);
 
   X509_STORE *store = NULL;
   X509_STORE_CTX *verify_ctx = NULL;
@@ -115,7 +115,7 @@ NAN_METHOD(get_altnames) {
   if(parsed_arg.size() == 0) {
     info.GetReturnValue().SetUndefined();
   }
-  Local<Object> exports(try_parse(parsed_arg)->ToObject());
+  Local<Object> exports(try_parse(parsed_arg)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   Local<Value> key = Nan::New<String>("altNames").ToLocalChecked();
   info.GetReturnValue().Set(
     Nan::Get(exports, key).ToLocalChecked());
@@ -128,7 +128,7 @@ NAN_METHOD(get_subject) {
   if(parsed_arg.size() == 0) {
     info.GetReturnValue().SetUndefined();
   }
-  Local<Object> exports(try_parse(parsed_arg)->ToObject());
+  Local<Object> exports(try_parse(parsed_arg)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   Local<Value> key = Nan::New<String>("subject").ToLocalChecked();
   info.GetReturnValue().Set(
     Nan::Get(exports, key).ToLocalChecked());
@@ -141,7 +141,7 @@ NAN_METHOD(get_issuer) {
   if(parsed_arg.size() == 0) {
     info.GetReturnValue().SetUndefined();
   }
-  Local<Object> exports(try_parse(parsed_arg)->ToObject());
+  Local<Object> exports(try_parse(parsed_arg)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   Local<Value> key = Nan::New<String>("issuer").ToLocalChecked();
   info.GetReturnValue().Set(
     Nan::Get(exports, key).ToLocalChecked());
@@ -154,7 +154,7 @@ NAN_METHOD(parse_cert) {
   if(parsed_arg.size() == 0) {
     info.GetReturnValue().SetUndefined();
   }
-  Local<Object> exports(try_parse(parsed_arg)->ToObject());
+  Local<Object> exports(try_parse(parsed_arg)->ToObject(Nan::GetCurrentContext()).ToLocalChecked());
   info.GetReturnValue().Set(exports);
   ERR_clear_error();
 }
@@ -459,7 +459,8 @@ Local<Value> parse_date(ASN1_TIME *date) {
 
   Local<Object> global = Nan::GetCurrentContext()->Global();
   Local<Object> DateObject = Nan::Get(global,
-    Nan::New<String>("Date").ToLocalChecked()).ToLocalChecked()->ToObject();
+    Nan::New<String>("Date").ToLocalChecked()).ToLocalChecked()
+      ->ToObject(Nan::GetCurrentContext()).ToLocalChecked();
   return scope.Escape(Nan::CallAsConstructor(DateObject, 1, args).ToLocalChecked());
 }
 


### PR DESCRIPTION
Currently it is not possible to build services using  [passport-wsfed-saml2](https://github.com/auth0/passport-wsfed-saml2) (lifeio-gateway, admin-gateway) against node v12 due to build errors with its version of node-x509, which hasn't been updated for over a year.  Last night I forked that repo and spent some time fixing those issues.  I submitted a PR against the original node-x509 repo.  I then went and checked and found 10 other PR's including 2 others that were also submitted to fix the issue (should have checked before doing my own) - going back to May 2019.  That they haven't been merged or addressed by the repo owner leads me to believe they have checked out.

So.. now thinking we should just do our own forks of this and passport-wsfed-saml2 - which has a number of other dependencies that could/should be updated.

Thoughts?